### PR TITLE
キーワードが日本語化されてしまっているのを戻す

### DIFF
--- a/docs/ide/create-portable-custom-editor-options.md
+++ b/docs/ide/create-portable-custom-editor-options.md
@@ -40,10 +40,10 @@ Visual Studio のエディターは、[EditorConfig プロパティ](http://edit
 - indent_size
 - tab_width
 - end\_of_line
-- 文字セット
+- charset
 - trim\_trailing_whitespace
 - insert\_final_newline
-- ルート
+- root
 
 EditorConfig エディター設定は、XML を除き、Visual Studio 対応のすべての言語でサポートされています。 また、EditorConfig では、C# および Visual Basic の[コード スタイル](../ide/editorconfig-code-style-settings-reference.md)と[名前付け](../ide/editorconfig-naming-conventions.md)規則がサポートされます。
 


### PR DESCRIPTION
EditorConfigの設定項目名が日本語化されていたので戻します。