### PR TITLE
Update troubleshooting-specific-errors-in-clickonce-deployments.md

### DIFF
--- a/docs/deployment/troubleshooting-specific-errors-in-clickonce-deployments.md
+++ b/docs/deployment/troubleshooting-specific-errors-in-clickonce-deployments.md
@@ -33,7 +33,7 @@ ms.locfileid: "39153600"
   
 ## <a name="general-errors"></a>一般的なエラー  
   
-#### <a name="when-you-try-to-locate-an-application-file-nothing-occurs-or-xml-renders-in-internet-explorer-or-you-receive-a-run-or-save-as-dialog-box"></a>ときに何も問題が発生すると、アプリケーション ファイルを検索しようとするまたは Internet Explorer で、XML を表示または実行または名前を付けて保存 ダイアログ ボックスが表示されます。  
+#### <a name="when-you-try-to-locate-an-application-file-nothing-occurs-or-xml-renders-in-internet-explorer-or-you-receive-a-run-or-save-as-dialog-box"></a>アプリケーション ファイルを配置しようとしたときに、何も起きない、または XML が Internet Explorer に表示される、または「実行または名前を付けて保存」のダイアログ ボックスが表示される。
  このエラーは、サーバーまたはクライアントに正しく登録されていないコンテンツの種類 (MIME の種類とも呼ばれます) による可能性があります。  
   
  まずに関連付けるサーバーが構成されていることを確認、 *.application*コンテンツを含む拡張機能の種類「/x ms-アプリケーションです」。  


### PR DESCRIPTION
Hi team,

I found a bit of unnatural sentences in Japanese language, and I believe this needs to be fixed. This PR:

- suggests that elaborating a document linguistically in Japanese language.
- is supposed to be addressed as a `Linguistic Suggestion` from my point of view.
- is in regard to https://docs.microsoft.com/ja-jp/visualstudio/deployment/troubleshooting-specific-errors-in-clickonce-deployments.

Best regards,