### PR TITLE
Fix missing

### DIFF
--- a/docs/debugger/c-cpp-assertions.md
+++ b/docs/debugger/c-cpp-assertions.md
@@ -338,7 +338,7 @@ _ASSERT(!myErr); // Don't do this, either!
 
 [このトピックの内容](#BKMK_In_this_topic)
 
-## <a name="see-also"></a>参照
+## <a name="see-also"></a>関連項目
 [デバッガーのセキュリティ](../debugger/debugger-security.md)  
 [ネイティブ コードのデバッグ](../debugger/debugging-native-code.md)  
 [マネージド コードのアサーション](../debugger/assertions-in-managed-code.md)


### PR DESCRIPTION
See also is not a `参照`, it is translated in the `関連項目` and in visualstudio-docs.ja-jp, azure-docs.ja-jp.