### PR TITLE
Fix missing

### DIFF
--- a/docs/debugger/debug-html-css-and-javascript-sample-code.md
+++ b/docs/debugger/debug-html-css-and-javascript-sample-code.md
@@ -100,5 +100,5 @@ ms.locfileid: "56227094"
 })();
 ```
 
-## <a name="see-also"></a>参照
+## <a name="see-also"></a>関連項目
 [クイック スタート: HTML および CSS のデバッグ](../debugger/quickstart-debug-html-and-css.md)


### PR DESCRIPTION
See also is not a `参照`, it is translated in the `関連項目` and in visualstudio-docs.ja-jp, azure-docs.ja-jp.