### PR TITLE
Fix missing

### DIFF
--- a/docs/debugger/how-to-debug-the-onstart-method.md
+++ b/docs/debugger/how-to-debug-the-onstart-method.md
@@ -52,6 +52,6 @@ Windows サービスをデバッグするには、サービスを起動し、デ
 
 5. Visual Studio の新しいインスタンスが開始し、 `Debugger.Launch()` メソッドで実行が停止します。
 
-## <a name="see-also"></a>参照
+## <a name="see-also"></a>関連項目
 [デバッガーのセキュリティ](../debugger/debugger-security.md)  
 [マネージド コードをデバッグする](../debugger/debugging-managed-code.md)


### PR DESCRIPTION
See also is not a `参照`, it is translated in the `関連項目` and in visualstudio-docs.ja-jp, azure-docs.ja-jp.