### PR TITLE
Fix missing

### DIFF
--- a/docs/debugger/how-to-specify-a-dotnet-framework-version-for-debugging.md
+++ b/docs/debugger/how-to-specify-a-dotnet-framework-version-for-debugging.md
@@ -64,5 +64,5 @@ The debugger has made an incorrect assumption about the [!INCLUDE[dnprdnshort](.
   
      それでもデバッグの開始時にエラー メッセージが表示される場合は、レジストリに正しいバージョン番号が入力されていることを確認します。 また、Visual Studio でサポートされている [!INCLUDE[dnprdnshort](../code-quality/includes/dnprdnshort_md.md)] のバージョンを使用していることを確認します。 デバッガーは、現在のバージョンおよび以前のバージョンの .NET Framework と互換性がありますが、将来のバージョンとの上位互換性はない可能性があります。  
   
-## <a name="see-also"></a>参照  
+## <a name="see-also"></a>関連項目  
  [デバッガーの設定と準備](../debugger/debugger-settings-and-preparation.md)


### PR DESCRIPTION
See also is not a `参照`, it is translated in the `関連項目` and in visualstudio-docs.ja-jp, azure-docs.ja-jp.