### PR TITLE
Fix missing

### DIFF
--- a/docs/debugger/how-to-test-and-debug-a-visualizer.md
+++ b/docs/debugger/how-to-test-and-debug-a-visualizer.md
@@ -53,7 +53,7 @@ ms.locfileid: "56227133"
 
     詳細な例では、次を参照してください。[チュートリアル: c# でビジュアライザーを記述する](../debugger/walkthrough-writing-a-visualizer-in-csharp.md)します。
 
-## <a name="see-also"></a>参照
+## <a name="see-also"></a>関連項目
 [チュートリアル : C# でビジュアライザーを記述する](../debugger/walkthrough-writing-a-visualizer-in-csharp.md)  
 [方法 : ビジュアライザーをインストールする](../debugger/how-to-install-a-visualizer.md)  
 [カスタム ビジュアライザーを作成する](../debugger/create-custom-visualizers-of-data.md)


### PR DESCRIPTION
See also is not a `参照`, it is translated in the `関連項目` and in visualstudio-docs.ja-jp, azure-docs.ja-jp.