### PR TITLE
Fix missing

### DIFF
--- a/docs/debugger/javascript-console-commands.md
+++ b/docs/debugger/javascript-console-commands.md
@@ -128,6 +128,6 @@ console.log("%s is %f years old!", user.first, user.age);
 // Fred is 10.01 years old!
 ```
 
-## <a name="see-also"></a>参照
+## <a name="see-also"></a>関連項目
 [クイックスタート: JavaScript のデバッグ](../debugger/quickstart-debug-javascript-using-the-console.md)  
 [クイック スタート: HTML および CSS のデバッグ](../debugger/quickstart-debug-html-and-css.md)


### PR DESCRIPTION
See also is not a `参照`, it is translated in the `関連項目` and in visualstudio-docs.ja-jp, azure-docs.ja-jp.