### PR TITLE
 タイトルから 2017 を除去

### DIFF
--- a/docs/install/modify-visual-studio.md
+++ b/docs/install/modify-visual-studio.md
@@ -1,5 +1,5 @@
 ---
-title: Visual Studio 2017 の変更
+title: Visual Studio の変更
 titleSuffix: ''
 description: Visual Studio を変更する方法について、ステップ バイ ステップで説明します。
 ms.custom: H1Hack27Feb2017,seodec18


### PR DESCRIPTION
Visual Studio 2019 の情報を表示している時にもタイトルが 2017 になってしまっています。( 英語のドキュメントでも 2017 は除去されています。 )